### PR TITLE
[HOTFIX] TSC Target Options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "ES2020",
+        "target": "ES2017",
         "types": ["node", "jest"],
         "module": "commonjs",
         "outDir": "./dist",


### PR DESCRIPTION
Was compiling to ES2020 instead of ES2017.